### PR TITLE
Оптимизировал поиск единиц времени by skykatik

### DIFF
--- a/src/main/java/darkdustry/PluginVars.java
+++ b/src/main/java/darkdustry/PluginVars.java
@@ -6,6 +6,8 @@ import com.google.gson.*;
 import darkdustry.components.Config;
 import darkdustry.features.votes.*;
 import mindustry.core.Version;
+import reactor.util.function.Tuple2;
+import reactor.util.function.Tuples;
 
 import static java.util.concurrent.TimeUnit.*;
 
@@ -79,11 +81,11 @@ public class PluginVars {
     public static final Pattern durationPattern = Pattern.compile("(?<!\\S)(\\d+)\\s*([a-zA-Zа-яА-Я]+)");
 
     /** Используются для перевода строки в длительность. */
-    public static final OrderedMap<Pattern, TimeUnit> durationPatterns = OrderedMap.of(
-            Pattern.compile("(d|day|days|д|день|дня|дней)"), DAYS,
-            Pattern.compile("(h|hour|hours|ч|час|часа|часов)"), HOURS,
-            Pattern.compile("(m|min|mins|minute|minutes|м|мин|минута|минуты|минут)"), MINUTES,
-            Pattern.compile("(s|sec|secs|second|seconds|с|сек|секунда|секунды|секунд)"), SECONDS
+    public static final Seq<Tuple2<Pattern, TimeUnit>> durationPatterns = Seq.with(
+            Tuples.of(Pattern.compile("(d|day|days|д|день|дня|дней)"), DAYS),
+            Tuples.of(Pattern.compile("(h|hour|hours|ч|час|часа|часов)"), HOURS),
+            Tuples.of(Pattern.compile("(m|min|mins|minute|minutes|м|мин|минута|минуты|минут)"), MINUTES),
+            Tuples.of(Pattern.compile("(s|sec|secs|second|seconds|с|сек|секунда|секунды|секунд)"), SECONDS)
     );
 
     /** Конфигурация сервера. */

--- a/src/main/java/darkdustry/utils/Utils.java
+++ b/src/main/java/darkdustry/utils/Utils.java
@@ -14,6 +14,7 @@ import mindustry.world.Block;
 
 import java.text.SimpleDateFormat;
 import java.time.*;
+import java.util.concurrent.TimeUnit;
 
 import static arc.util.Strings.*;
 import static darkdustry.PluginVars.*;
@@ -108,10 +109,14 @@ public class Utils {
             long amount = Strings.parseLong(matcher.group(1), 0);
             if (amount == 0) continue;
 
-            var pattern = durationPatterns.orderedKeys().find(key -> key.matcher(matcher.group(2).toLowerCase()).matches());
-            if (pattern == null) continue;
-
-            time += durationPatterns.get(pattern).toSeconds(amount);
+            String timeUnitString = matcher.group(2).toLowerCase();
+            for (var tuple : durationPatterns) {
+                if (tuple.getT1().matcher(timeUnitString).matches()) {
+                    TimeUnit timeUnit = tuple.getT2();
+                    time += timeUnit.toSeconds(amount);
+                    break;
+                }
+            }
         }
 
         return Duration.ofSeconds(time);


### PR DESCRIPTION
Избегай код типа:
```
var key = map.keys().find(k -> k.startsWith("123");
var value = map.get(key);
```
Это всегда хуже, чем взять entries() и найти нужное, так как на ключах могут быть коллизии. Но в данном случае карта вовсе не нужна. Это массив пар шаблон->единица